### PR TITLE
feat(player): modify SpatialNavigation class  & Component class

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1331,20 +1331,51 @@ class Component {
   }
 
   /**
-   * Abstract method to handle the focus event. This method should be overridden
+   * Handles the focus event. This method could be overridden
    * in subclasses to provide specific focus event handling.
    *
-   * @abstract
+   * Calls for handling of the Player Focus if:
+   * * SpatialNavigation is enabled, not paused & element is focusable.
    */
-  handleFocus() {}
+  handleFocus() {
+    // eslint-disable-next-line
+    const SpatialNavigation = window.SpatialNavigation;
+
+    if (SpatialNavigation && SpatialNavigation.isPaused && this.getIsFocusable()) {
+      SpatialNavigation.handlePlayerFocus();
+    }
+  }
 
   /**
-   * Abstract method to handle the blur event. This method should be overridden
-   * in subclasses to provide specific blur event handling.
+   * Handles the blur event. This method could be overridden
+   * in subclasses to provide specific focus event handling.
    *
-   * @abstract
+   * @param {string|Event|Object} event
+   *        The name of the event, an `Event`, or an object with a key of type set to
+   *        an event name.
+   *
+   * Calls for handling of the Player Blur if:
+   * * Next focused element is not a children of current focused element &
+   *   next focused element is not a children of Player.
+   * * There is no next focused element
    */
-  handleBlur() {}
+  handleBlur(event) {
+    // eslint-disable-next-line
+    const SpatialNavigation = window.SpatialNavigation;
+
+    if (SpatialNavigation && this.getIsFocusable()) {
+      const nextFocusedElement = event.relatedTarget;
+      let isChildrenOfPlayer = null;
+
+      if (nextFocusedElement) {
+        isChildrenOfPlayer = Boolean(nextFocusedElement.closest('.video-js'));
+      }
+
+      if (!(event.currentTarget.contains(event.relatedTarget)) && !isChildrenOfPlayer || !nextFocusedElement) {
+        SpatialNavigation.handlePlayerBlur();
+      }
+    }
+  }
 
   /**
    * Set the focus to this component

--- a/src/js/spatial-navigation.js
+++ b/src/js/spatial-navigation.js
@@ -92,6 +92,22 @@ class SpatialNavigation {
   }
 
   /**
+   * Handles Player Blur.
+   *
+   */
+  handlePlayerBlur() {
+    this.pause();
+  }
+
+  /**
+   * Handles Player Focus.
+   *
+   */
+  handlePlayerFocus() {
+    this.resume();
+  }
+
+  /**
    * Gets a set of focusable components.
    *
    * @return {Array}


### PR DESCRIPTION
Modify SpatialNavigation class:
-Add function ‘handlePlayerBlur’
-Add function ‘handlePlayerFocus’
Modify Component class:
-Modify ‘handleBlur’
-Modify ‘handleFocus’

## Description
This is require to complete the point of "we should provide events-based API for cases when the player enters/leaves focus so that the client app can call the player.spatialNavigation.pause/resume" of ticket: https://brightcove.atlassian.net/browse/WP-1372.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
